### PR TITLE
Add benchmark suite for performance of parsing date-formatted string

### DIFF
--- a/cli/benchmark.ts
+++ b/cli/benchmark.ts
@@ -291,7 +291,7 @@ const runMixedTZ = async () => {
 };
 
 const runParse = async () => {
-    console.warn(`#### parse()`);
+    console.warn(`#### parse().format()`);
     await runBenchmark({
         cdate: () => cdate("2022-01-01 00:00:00").format(COMPAT_FORMAT),
         moment: () => moment("2022-01-01 00:00:00").format(COMPAT_FORMAT),

--- a/cli/benchmark.ts
+++ b/cli/benchmark.ts
@@ -214,6 +214,8 @@ const main = async () => {
     if (!RUN_EACH) {
         await runMixedTZ();
     }
+
+    await runParse()
 };
 
 const runEachLocal = async () => {
@@ -287,5 +289,15 @@ const runMixedTZ = async () => {
         luxon: () => luxonMixed(() => DateTime.fromJSDate(dt, {zone: "America/New_York"})),
     });
 };
+
+const runParse = async () => {
+    console.warn(`#### parse()`);
+    await runBenchmark({
+        cdate: () => cdate("2022-01-01 00:00:00").format(COMPAT_FORMAT),
+        moment: () => moment("2022-01-01 00:00:00").format(COMPAT_FORMAT),
+        dayjs: () => dayjs("2022-01-01 00:00:00").format(COMPAT_FORMAT),
+        luxon: () => DateTime.fromSQL("2022-01-01 00:00:00").toFormat(LUXON_FORMAT),
+    })
+}
 
 main().catch(console.error);


### PR DESCRIPTION
Add benchmark suite (in source code, `runParse()`).

I have separated it from existing suites because its performance is not dependent on operating instance with time-zone.